### PR TITLE
Added Twig ^3.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ composer require mikealmond/twig-color-extension
 
 ```twig
 {{ '0099FF'|color_darken(20)|color_css_rgba(0.9) }}
-{{ '0099FF' is color_is_dark ? 'dark' : 'light' }}
+{{ '0099FF' is color_dark ? 'dark' : 'light' }}
 {{ '0099FF'|color_complementary(30)|color_css_hex }}
 {{ '0099FF' is color_low_contrast ? 'default-color' : '0099FF'|color_css_hex }}
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "ext-ctype": "*",
     "ext-json": "*",
     "mikealmond/color": "^0.1.0",
-    "twig/twig": "^1.2|^2.5"
+    "twig/twig": "^1.2|^2.5|^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.0",

--- a/tests/ColorExtensionTest.php
+++ b/tests/ColorExtensionTest.php
@@ -108,7 +108,11 @@ class ColorExtensionTest extends TestCase
      */
     public function testInvalidFilters()
     {
-        $this->expectException(Twig_Error_Syntax::class);
+        if (class_exists('\\Twig_Error_Syntax')) {
+            $this->expectException(Twig_Error_Syntax::class);
+        } else {
+            $this->expectException(\Twig\Error\SyntaxError::class);
+        }
         $this->assertRender('hsla(204, 100%, 50%, 0.5)', "{{ '0099FF'|colour_css_hsla(0.5) }}");
     }
 
@@ -177,10 +181,17 @@ class ColorExtensionTest extends TestCase
      */
     protected function buildEnv($template)
     {
-        $loader = new \Twig_Loader_Array([
-            'template' => $template,
-        ]);
-        $twig   = new \Twig_Environment($loader);
+        if (class_exists('\\Twig_Loader_Array')) {
+            $loader = new \Twig_Loader_Array([
+                'template' => $template,
+            ]);
+            $twig   = new \Twig_Environment($loader);
+        } else {
+            $loader = new \Twig\Loader\ArrayLoader([
+                'template' => $template,
+            ]);
+            $twig   = new \Twig\Environment($loader);
+        }
 
         $twig->addExtension($this->getExtension());
 


### PR DESCRIPTION
Oy there!

I wanted to use this extension in a new project with Twig 3.1, so here is a pull request to allow usage of this extension with Twig 3.0+.

I've tried it in a project without any issues, so the source code of the extension didn't seem to require any changes.
However, I have updated the unit test seeing as the `Twig_` classes weren't available in Twig 3.

I also fixed a minor error in the Usage section of the README, where the `color_dark` test seemed erroneously referenced to as `color_is_dark`.

Let me know if you need any more information to merge this.

Cheers!